### PR TITLE
Feature/argument enhancements

### DIFF
--- a/pymaengda/application.py
+++ b/pymaengda/application.py
@@ -76,25 +76,11 @@ class Application():
 
 
     def run(self):
-        '''I think a lot of the below block, regarding custom read arguments
-        and such may be better off in it's own function. I can see it being
-        reused. Might it be best in the Data class though?'''
-
-        # Test command. Yes, it works.
-        #write = self.reader.write_data(data_dir + data_file + '.out', data)
-
-        '''Main program logic loop. Parse the values given on the command
-        line and execute the desired functions. In many cases, this will
-        only loop once. Certain cases such as updating a row will result
-        in the loop repeating to display the updated row.
-
-        Runlevels:
-          0 - quit
-          1 - display
-          2 - edit
-          3 - create
-          4 - delete
-          8 - statistics'''
+        '''At this point, we have already created our Data instance and parsed
+        arguments. We can begin branching off into different execution modes.
+        Certain modes should display the data after the action has been
+        performed as a sort of verification. In these cases, just call
+        self.display() again.'''
         if self.args.mode == 'list':
             self.display()
         elif self.args.mode == 'edit':

--- a/pymaengda/application.py
+++ b/pymaengda/application.py
@@ -83,42 +83,30 @@ class Application():
         # Test command. Yes, it works.
         #write = self.reader.write_data(data_dir + data_file + '.out', data)
 
-        if self.args.runlevel is not None:
-            runlevel = self.args.runlevel
+        '''Main program logic loop. Parse the values given on the command
+        line and execute the desired functions. In many cases, this will
+        only loop once. Certain cases such as updating a row will result
+        in the loop repeating to display the updated row.
+
+        Runlevels:
+          0 - quit
+          1 - display
+          2 - edit
+          3 - create
+          4 - delete
+          8 - statistics'''
+        if self.args.mode == 'list':
+            self.display()
+        elif self.args.mode == 'edit':
+            self.edit()
+            self.display()
+        elif self.args.mode == 'burn':
+            self.create()
+            self.display()
+        elif self.args.mode == 'rm':
+            self.delete()
+            self.display()
+        elif self.args.mode == 'stats':
+            print('statistics')
         else:
-            runlevel = 1
-
-        while runlevel > 0:
-            '''Main program logic loop. Parse the values given on the command
-            line and execute the desired functions. In many cases, this will
-            only loop once. Certain cases such as updating a row will result
-            in the loop repeating to display the updated row.
-
-            Runlevels:
-              0 - quit
-              1 - display
-              2 - edit
-              3 - create
-              4 - delete
-              8 - statistics'''
-            if runlevel == 0:
-                print('quit')
-                break
-            elif runlevel == 1:
-                self.display()
-                runlevel = 0
-            elif runlevel == 2:
-                self.edit()
-                runlevel = 1
-            elif runlevel == 3:
-                self.create()
-                runlevel = 1
-            elif runlevel == 4:
-                self.delete()
-                runlevel = 1
-            elif runlevel == 8:
-                print('statistics')
-                runlevel = 1
-            else:
-                print('Unknown runlevel')
-                runlevel = 0
+            print('Unknown mode')

--- a/pymaengda/arguments.py
+++ b/pymaengda/arguments.py
@@ -16,13 +16,6 @@ class Arguments():
 
     def parse_args(self):
         print('parse_args')
-        self.parser.add_argument(
-                '-r', '--runlevel',
-                default=1,
-                choices=[0,1,2,3,4,8],
-                type=int,
-                help='runlevel to start in',
-                dest='runlevel')
         #self.parser.add_argument(
         #        '-a', '--amount',
         #        type=float,
@@ -80,7 +73,6 @@ class Arguments():
                 help='full output mode')
 
         self.args = self.parser.parse_args()
-        #print(f"self.args.runlevel='{self.args.runlevel}'")
         if self.args.mode == 'burn':
             print(f"self.args.amount='{self.args.amount}', self.args.strain='{self.args.strain}'")
         elif self.args.mode == 'rm':

--- a/pymaengda/arguments.py
+++ b/pymaengda/arguments.py
@@ -70,6 +70,15 @@ class Arguments():
                 default=1,
                 help='remove MOST_RECENT burns')
 
+        self.stats_parser = self.subparsers.add_parser(
+                'stats',
+                help='display various statistics')
+        self.stats_parser.add_argument(
+                '--full',
+                default=False,
+                action='store_true',
+                help='full output mode')
+
         self.args = self.parser.parse_args()
         #print(f"self.args.runlevel='{self.args.runlevel}'")
         if self.args.mode == 'burn':

--- a/pymaengda/arguments.py
+++ b/pymaengda/arguments.py
@@ -5,7 +5,10 @@ class Arguments():
     def __init__(self):
         print('Arguments.__init__')
         self.parser = argparse.ArgumentParser(
-                description='Quick & easy to use kratom burn tracking software'
+                description='''
+                Quick & easy to use kratom burn tracking software
+                https://github.com/ncdulo/pymaengda
+                '''
             )
 
     def parse_args(self):

--- a/pymaengda/arguments.py
+++ b/pymaengda/arguments.py
@@ -16,16 +16,7 @@ class Arguments():
 
     def parse_args(self):
         print('parse_args')
-        #self.parser.add_argument(
-        #        '-a', '--amount',
-        #        type=float,
-        #        help='amount (in grams) of the burn',
-        #        dest='amount')
-        #self.parser.add_argument(
-        #        '-s', '--strain',
-        #        type=str,
-        #        help='strain name',
-        #        dest='strain')
+
         self.list_parser = self.subparsers.add_parser(
                 'list', help='list burns')
         self.list_parser.add_argument(

--- a/pymaengda/arguments.py
+++ b/pymaengda/arguments.py
@@ -73,6 +73,8 @@ class Arguments():
                 help='full output mode')
 
         self.args = self.parser.parse_args()
+
+        '''Debug text below. Remove for release.'''
         if self.args.mode == 'burn':
             print(f"self.args.amount='{self.args.amount}', self.args.strain='{self.args.strain}'")
         elif self.args.mode == 'rm':

--- a/pymaengda/arguments.py
+++ b/pymaengda/arguments.py
@@ -4,7 +4,9 @@ import argparse
 class Arguments():
     def __init__(self):
         print('Arguments.__init__')
-        self.parser = argparse.ArgumentParser()
+        self.parser = argparse.ArgumentParser(
+                description='Quick & easy to use kratom burn tracking software'
+            )
 
     def parse_args(self):
         print('parse_args')

--- a/pymaengda/arguments.py
+++ b/pymaengda/arguments.py
@@ -33,6 +33,14 @@ class Arguments():
         #        type=str,
         #        help='strain name',
         #        dest='strain')
+        self.list_parser = self.subparsers.add_parser(
+                'list', help='list burns')
+        self.list_parser.add_argument(
+                '--most-recent',
+                dest='most_recent',
+                type=int,
+                default=5,
+                help='display MOST_RECENT burns, default 5')
         self.edit_parser = self.subparsers.add_parser(
                 'edit', help='not yet implemented')
         self.edit_parser.add_argument(

--- a/pymaengda/arguments.py
+++ b/pymaengda/arguments.py
@@ -41,6 +41,7 @@ class Arguments():
                 type=int,
                 default=5,
                 help='display MOST_RECENT burns, default 5')
+
         self.edit_parser = self.subparsers.add_parser(
                 'edit', help='not yet implemented')
         self.edit_parser.add_argument(
@@ -61,13 +62,13 @@ class Arguments():
 
         self.rm_parser = self.subparsers.add_parser(
                 'rm',
-                help='remove specific entries')
+                help='remove specific burns')
         self.rm_parser.add_argument(
                 '--most-recent',
                 dest='most_recent',
                 type=int,
                 default=1,
-                help='remove MOST_RECENT entries')
+                help='remove MOST_RECENT burns')
 
         self.args = self.parser.parse_args()
         #print(f"self.args.runlevel='{self.args.runlevel}'")

--- a/pymaengda/arguments.py
+++ b/pymaengda/arguments.py
@@ -10,7 +10,9 @@ class Arguments():
                 https://github.com/ncdulo/pymaengda
                 '''
             )
-        self.subparsers = self.parser.add_subparsers(help='modes')
+        self.subparsers = self.parser.add_subparsers(
+                dest='mode',
+                help='modes')
 
     def parse_args(self):
         print('parse_args')
@@ -32,18 +34,32 @@ class Arguments():
         #        help='strain name',
         #        dest='strain')
         self.burn_parser = self.subparsers.add_parser(
-                'burn', help='Add a burn')
+                'burn', help='add a burn')
         self.burn_parser.add_argument(
                 'amount',
                 type=float,
-                help='Amount in grams')
+                help='amount in grams')
         self.burn_parser.add_argument(
                 'strain',
                 type=str,
-                help='Name of strain burned')
+                help='name of strain burned')
+
+        self.rm_parser = self.subparsers.add_parser(
+                'rm',
+                help='remove specific entries')
+        self.rm_parser.add_argument(
+                '--most-recent',
+                dest='most_recent',
+                type=int,
+                default=1,
+                help='remove MOST_RECENT entries')
 
         self.args = self.parser.parse_args()
-        print(f"self.args.runlevel='{self.args.runlevel}'")
-        print(f"self.args.amount='{self.args.amount}', self.args.strain='{self.args.strain}'")
+        #print(f"self.args.runlevel='{self.args.runlevel}'")
+        if self.args.mode == 'burn':
+            print(f"self.args.amount='{self.args.amount}', self.args.strain='{self.args.strain}'")
+        elif self.args.mode == 'rm':
+            print(f'self.args.most_recent = {self.args.most_recent}')
+        print(f'self.args.mode = {self.args.mode}')
 
         return self.args

--- a/pymaengda/arguments.py
+++ b/pymaengda/arguments.py
@@ -33,6 +33,13 @@ class Arguments():
         #        type=str,
         #        help='strain name',
         #        dest='strain')
+        self.edit_parser = self.subparsers.add_parser(
+                'edit', help='not yet implemented')
+        self.edit_parser.add_argument(
+                'id',
+                type=int,
+                help='id of entry to edit')
+
         self.burn_parser = self.subparsers.add_parser(
                 'burn', help='add a burn')
         self.burn_parser.add_argument(

--- a/pymaengda/arguments.py
+++ b/pymaengda/arguments.py
@@ -10,6 +10,7 @@ class Arguments():
                 https://github.com/ncdulo/pymaengda
                 '''
             )
+        self.subparsers = self.parser.add_subparsers(help='modes')
 
     def parse_args(self):
         print('parse_args')
@@ -20,16 +21,27 @@ class Arguments():
                 type=int,
                 help='runlevel to start in',
                 dest='runlevel')
-        self.parser.add_argument(
-                '-a', '--amount',
+        #self.parser.add_argument(
+        #        '-a', '--amount',
+        #        type=float,
+        #        help='amount (in grams) of the burn',
+        #        dest='amount')
+        #self.parser.add_argument(
+        #        '-s', '--strain',
+        #        type=str,
+        #        help='strain name',
+        #        dest='strain')
+        self.burn_parser = self.subparsers.add_parser(
+                'burn', help='Add a burn')
+        self.burn_parser.add_argument(
+                'amount',
                 type=float,
-                help='amount (in grams) of the burn',
-                dest='amount')
-        self.parser.add_argument(
-                '-s', '--strain',
+                help='Amount in grams')
+        self.burn_parser.add_argument(
+                'strain',
                 type=str,
-                help='strain name',
-                dest='strain')
+                help='Name of strain burned')
+
         self.args = self.parser.parse_args()
         print(f"self.args.runlevel='{self.args.runlevel}'")
         print(f"self.args.amount='{self.args.amount}', self.args.strain='{self.args.strain}'")


### PR DESCRIPTION
The basic arguments API has been implemented with this feature branch. Using `argparse` sub-parsers we are able to retrieve command line arguments in a clear and concise manner. This system should allow greater ease-of-use and more flexibility in future arguments being added.

For now, the base set of sub-parsers has been implemented for our main modes. List, Edit, Burn, Rm, and Stats. Each may have it's own specific set of arguments to be passed into it.

The main Application.run() method has been updated as well to remove `runlevel` and replace it with `self.args.mode`. This will remove the need to specify numeric arguments to select the mode on the command line, as well as enhance code readability.

This closes [issue 4](https://github.com/ncdulo/pymaengda/issues/4)