### PR TITLE
Default to list mode when no arguments given

### DIFF
--- a/suppylement/arguments.py
+++ b/suppylement/arguments.py
@@ -1,3 +1,5 @@
+import sys
+
 import argparse
 
 
@@ -63,7 +65,13 @@ class Arguments():
                 action='store_true',
                 help='full output mode')
 
-        self.args = self.parser.parse_args()
+        # If we are not given enough arguments, provide a default of list
+        # mode to the user.
+        print(sys.argv)
+        if (len(sys.argv) < 2):
+            self.args = self.parser.parse_args(args=['list'])
+        else:
+            self.args = self.parser.parse_args()
 
         '''Debug text below. Remove for release.'''
         if self.args.mode == 'log':


### PR DESCRIPTION
This commit resolves Issue #10. When Suppylement is run with no command
line arguments provided, we will enter `list` mode by default. This is a
bit of an easy alias for a quick glance at the most recent entries.

To implement this feature, we check the length of the `sys.argv` list.
If there are less than two items (program name, argument, [argument,
..]`, we call `parse_args()` with our own argument string.

In the future, when working on issue #7, we will likely need to refactor this
code to properly account for custom argument strings. It is entirely
possible we move this code to a more proper location for such a task.
One candidate being `main.py`. For now, it stands.