### PR TITLE
remove sh/python and path to executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ source .env/bin/activate
 # Install dependencies
 pip install -r requirements.txt
 
+# Ensure script is executable
+chmod +x bin/suppylement
+
 # To run via wrapper (recommended)
 bin/suppylement --help
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ chmod +x bin/suppylement
 bin/suppylement --help
 
 # To run directly
-suppylement/main.py --help
+python suppylement/main.py --help
 
 # If using virtual environment, to disable it when finished run:
 deactivate

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ source .env/bin/activate
 pip install -r requirements.txt
 
 # To run via wrapper (recommended)
-sh bin/suppylement --help
+bin/suppylement --help
 
 # To run directly
-python suppylement/main.py --help
+suppylement/main.py --help
 
 # If using virtual environment, to disable it when finished run:
 deactivate
@@ -75,27 +75,27 @@ that some (most) functionality is currently not fully implemented.
 
 ```
 # Display help
-sh bin/suppylement --help
-sh bin/suppylement log --help
+suppylement --help
+suppylement log --help
 
 # List most recent 5 entries
-sh bin/suppylement list
+suppylement list
 # List most recent 20 entries
-sh bin/suppylement list --most-recent 20
+suppylement list --most-recent 20
 
 # Log a new entry
-sh bin/suppylement log 1000 VitaminC
-sh bin/suppylement log 250 magnesium-citrate
+suppylement log 1000 VitaminC
+suppylement log 250 magnesium-citrate
 
 # Delete the most recent entry
-sh bin/suppylement rm
+suppylement rm
 # Delete the most recent 5 entries
-sh bin/suppylement rm --most-recent 5
+suppylement rm --most-recent 5
 
 # View statistics
-sh bin/suppylement stats
+suppylement stats
 # View full statistics
-sh bin/suppylement stats --full
+suppylement stats --full
 ```
 
 Development Goals & Roadmap


### PR DESCRIPTION
No need to specify sh or python as long as you have the correct crunchbang on the appropriate files.

No need to specify the path to the executable as long as you symlinked to `/usr/local/bin`