### PR TITLE
Ability to pass custom arguments to `Application`

### DIFF
--- a/suppylement/application.py
+++ b/suppylement/application.py
@@ -2,6 +2,7 @@ import arguments
 import data
 
 import os
+import sys
 
 
 ''' Basic program structure
@@ -18,7 +19,7 @@ Display output'''
 
 
 class Application():
-    def __init__(self):
+    def __init__(self, args=None):
         '''This seems like a good place to parse our arguments and decide
         the best course of action. We do not read any data here as some
         argument combinations will not require any to be read (help, version
@@ -26,10 +27,21 @@ class Application():
         data_dir = os.path.dirname(os.path.abspath(__file__)) + '/../data'
         data_csv = '/test.csv'
         data_file = data_dir + data_csv
-
         self.reader = data.Data(data_file, data_file + '.out')
+
         self.arguments = arguments.Arguments()
-        self.args = self.arguments.parse_args()
+        # If no args provided, default to command line args
+        if args is None:
+            # If command line args do not include any mode, default to list
+            if len(sys.argv) < 2:
+                self.args = self.arguments.parse_args(['list'])
+            # Command line args are long enough
+            else:
+                print(sys.argv[1:])
+                self.args = self.arguments.parse_args(sys.argv[1:])
+        # We have been given a custom argument list
+        else:
+            self.args = self.arguments.parse_args(args)
 
         self.default_read_args = {
                 'index_col': 0

--- a/suppylement/arguments.py
+++ b/suppylement/arguments.py
@@ -16,7 +16,7 @@ class Arguments():
                 dest='mode',
                 help='modes')
 
-    def parse_args(self):
+    def parse_args(self, args):
         print('parse_args')
 
         self.list_parser = self.subparsers.add_parser(
@@ -65,12 +65,7 @@ class Arguments():
                 action='store_true',
                 help='full output mode')
 
-        # If we are not given enough arguments, provide a default of list
-        # mode to the user.
-        if (len(sys.argv) < 2):
-            self.args = self.parser.parse_args(args=['list'])
-        else:
-            self.args = self.parser.parse_args()
+        self.args = self.parser.parse_args(args)
 
         '''Debug text below. Remove for release.'''
         if self.args.mode == 'log':


### PR DESCRIPTION
This PR implements a custom argument list functionality with default behavior to use command line arguments. If no command line arguments are provided, default to `list` mode. This PR also undoes the changes in PR #17 as I feel `Application` is a better home for this functionality. Better separation of objects and logic or something. In the end, this resolves issue #7. 