### PR TITLE
Delete mode basic implementation

### DIFF
--- a/suppylement/application.py
+++ b/suppylement/application.py
@@ -119,7 +119,17 @@ Error: search_more ({self.args.search_more}) must be greater than 0''')
             self.reader.write_data(mode='w')
 
     def delete(self):
-        pass
+        data = self.reader.read_data(**self.default_read_args)
+
+        # Ensure our ID is greater than 0, less than number of rows
+        try:
+            self.reader.delete_row_by_id(self.args.id_to_remove)
+        except ValueError as error:
+            print(f'ValueError caught!\n{error}')
+            print('\n\n  Entry NOT deleted!\n\n')
+        else:
+            print('Entry removed!')
+            self.reader.write_data()
 
     def run(self):
         '''At this point, we have already created our Data instance and parsed

--- a/suppylement/application.py
+++ b/suppylement/application.py
@@ -123,13 +123,17 @@ Error: search_more ({self.args.search_more}) must be greater than 0''')
 
         # Ensure our ID is greater than 0, less than number of rows
         try:
-            self.reader.delete_row_by_id(self.args.id_to_remove)
+            success = self.reader.delete_row_by_id(self.args.id_to_remove,
+                    self.args.rm_interactive)
         except ValueError as error:
             print(f'ValueError caught!\n{error}')
             print('\n\n  Entry NOT deleted!\n\n')
         else:
-            print('Entry removed!')
-            self.reader.write_data()
+            if success:
+                print('Entry removed!')
+                self.reader.write_data()
+            else:
+                print('Entry not removed!')
 
     def run(self):
         '''At this point, we have already created our Data instance and parsed

--- a/suppylement/arguments.py
+++ b/suppylement/arguments.py
@@ -73,6 +73,12 @@ class Arguments():
                 default=-1,
                 help='remove entry number ID_TO_REMOVE')
         self.rm_parser.add_argument(
+                '-i',
+                dest='rm_interactive',
+                action='store_true',
+                default=False,
+                help='confirm before deleting row')
+        self.rm_parser.add_argument(
                 '--most-recent',
                 dest='most_recent',
                 type=int,

--- a/suppylement/arguments.py
+++ b/suppylement/arguments.py
@@ -67,6 +67,12 @@ class Arguments():
                 'rm',
                 help='remove specific entries')
         self.rm_parser.add_argument(
+                '--id',
+                dest='id_to_remove',
+                type=int,
+                default=-1,
+                help='remove entry number ID_TO_REMOVE')
+        self.rm_parser.add_argument(
                 '--most-recent',
                 dest='most_recent',
                 type=int,

--- a/suppylement/data.py
+++ b/suppylement/data.py
@@ -79,7 +79,7 @@ class Data():
                 print(f'Exception caught in new_entry!\n{error}')
                 return None
 
-    def delete_row_by_id(self, id_to_remove):
+    def delete_row_by_id(self, id_to_remove, confirm=False):
         '''Remove a row as specified by it's index value. There is some
         bounds checking to ensure the ID is within the limits of the
         DataFrame. The index will also be reset so the values flow without
@@ -90,9 +90,16 @@ class Data():
             print(f'Removing entry ID {id_to_remove}:')
             print(self._data.iloc[id_to_remove])
             print()
+            if confirm:
+                choice = input('Are you sure you want to delete this entry? '
+                        "Enter 'Y' to confirm.\n > ")
+                if not choice == 'Y':
+                    print('Aborted')
+                    return None
             # Delete the requested row and then reset our index column
             self._data = self._data.drop(self._data.index[id_to_remove])
             self._data.reset_index(drop=True, inplace=True)
+            return True
         else:
             raise ValueError('Error id_to_remove out of bounds!\n'
                     f'(0 <= {id_to_remove} <= {len(self._data)-1})')

--- a/suppylement/data.py
+++ b/suppylement/data.py
@@ -78,3 +78,21 @@ class Data():
             except TypeError as error:
                 print(f'Exception caught in new_entry!\n{error}')
                 return None
+
+    def delete_row_by_id(self, id_to_remove):
+        '''Remove a row as specified by it's index value. There is some
+        bounds checking to ensure the ID is within the limits of the
+        DataFrame. The index will also be reset so the values flow without
+        gaps after removal. Following in design for other members of this
+        class, we do not save any data. We only update the values and leave
+        it up to Application to verify and/or save data when necessary.'''
+        if 0 <= id_to_remove <= len(self._data)-1:
+            print(f'Removing entry ID {id_to_remove}:')
+            print(self._data.iloc[id_to_remove])
+            print()
+            # Delete the requested row and then reset our index column
+            self._data = self._data.drop(self._data.index[id_to_remove])
+            self._data.reset_index(drop=True, inplace=True)
+        else:
+            raise ValueError('Error id_to_remove out of bounds!\n'
+                    f'(0 <= {id_to_remove} <= {len(self._data)-1})')


### PR DESCRIPTION
Covered in this PR is a basic delete mode implementation. The user is able to specify a row ID number, optionally ask for confirmation, then finally delete the row and if successful write the data back to disk. There is some basic error and bounds checking but it could use some improvement. Local testing showed no issues or data loss, except the specified data, of course.

This PR partially implements the functionality requested in issue #26 