### PR TITLE
Replace `os` module with `pathlib`

### DIFF
--- a/suppylement/application.py
+++ b/suppylement/application.py
@@ -26,8 +26,8 @@ class Application():
         argument combinations will not require any to be read (help, version
         information). '''
         self.config = configuration.Configuration(
-                '/suppylement_defaults.ini',
-                '/suppylement.ini')
+                'suppylement_defaults.ini',
+                'suppylement.ini')
 
         self.reader = data.Data(self.config.read_file,
                 self.config.write_file)

--- a/suppylement/application.py
+++ b/suppylement/application.py
@@ -2,7 +2,6 @@ import arguments
 import configuration
 import data
 
-import os
 import sys
 
 

--- a/suppylement/arguments.py
+++ b/suppylement/arguments.py
@@ -1,5 +1,3 @@
-import sys
-
 import argparse
 
 

--- a/suppylement/configuration.py
+++ b/suppylement/configuration.py
@@ -1,5 +1,5 @@
 import configparser
-import os
+import pathlib
 
 
 class Configuration():
@@ -11,9 +11,11 @@ class Configuration():
     def __init__(self, default_config_file, user_config_file):
         '''Set up our configparser instance. Read default values.
         Apply user values on top of default values.'''
-        self.base_dir = os.path.dirname(os.path.abspath(__file__))
-        self.default_config_file = self.base_dir + default_config_file
-        self.user_config_file = self.base_dir + user_config_file
+        self.base_dir = pathlib.Path(__file__).parent.resolve()
+        self.default_config_file = self.base_dir /\
+                pathlib.Path(default_config_file)
+        self.user_config_file = self.base_dir /\
+                pathlib.Path(user_config_file)
         # TODO: Prefer USER_CONFIG_DIR from appdirs module, if it exists.
 
         self.parser = configparser.ConfigParser()
@@ -25,9 +27,9 @@ class Configuration():
         # Assemble our data file path here. This allows the config file
         # to use relative paths to the data file. It is also a shorter
         # alias for `self.config.parser.get('read_file')`.
-        self.read_file = self.base_dir +\
+        self.read_file = self.base_dir /\
                 self.parser.get('filenames', 'read_file')
-        self.write_file = self.base_dir +\
+        self.write_file = self.base_dir /\
                 self.parser.get('filenames', 'write_file')
 
         # Debug text below

--- a/suppylement/data.py
+++ b/suppylement/data.py
@@ -2,7 +2,7 @@ import datetime
 
 import pandas as pd
 import pandas.errors as pd_error
-import os.path
+import pathlib
 
 
 class Data():
@@ -16,7 +16,7 @@ class Data():
         else:
             self.write_file = write_file
         # Check to ensure our read file actually exists before we need it.
-        if not os.path.isfile(self.read_file):
+        if not pathlib.Path(self.read_file).exists():
             raise FileNotFoundError(f'read_file not found!\n{self.read_file}')
 
     def read_data(self, *args, **kwargs):

--- a/suppylement/suppylement_defaults.ini
+++ b/suppylement/suppylement_defaults.ini
@@ -3,8 +3,8 @@
 # edit that file instead. Any settings in that file will over-ride the
 # settings in this file
 [filenames]
-read_file=/../data/data.csv
-write_file=/../data/data.csv
+read_file=../data/data.csv
+write_file=../data/data.csv
 
 [defaults]
 custom_args=list


### PR DESCRIPTION
With the work towards using `pathlib` instead of `os` to handle filenames and paths complete, let's get that merge going. This pull request implements the feature as requested in Issue #31 and my testing shows no issues at run-time.

Full description of the work can be gathered from the commit history, and impending merge commit. This merge resolves Issue #31.